### PR TITLE
fix: update copyright year to use 'present' and add headers to test files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024-2026 Datadog, Inc.
+   Copyright 2024-present Datadog, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 Datadog API Claude Plugin
-Copyright 2024-2026 Datadog, Inc.
+Copyright 2024-present Datadog, Inc.
 
 This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/README.md
+++ b/README.md
@@ -769,7 +769,7 @@ Apache License 2.0 - see [LICENSE](LICENSE) for details.
 Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 
 This product includes software developed at Datadog (https://www.datadoghq.com/).
-Copyright 2024-2026 Datadog, Inc.
+Copyright 2024-present Datadog, Inc.
 
 ## Support
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 import js from "@eslint/js";
 import globals from "globals";

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {

--- a/src/api/v1/dashboards.ts
+++ b/src/api/v1/dashboards.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Dashboards API operations (v1)

--- a/src/api/v1/hosts.ts
+++ b/src/api/v1/hosts.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Hosts API operations (v1)

--- a/src/api/v1/monitors.ts
+++ b/src/api/v1/monitors.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Monitors API operations (v1)

--- a/src/api/v1/slos.ts
+++ b/src/api/v1/slos.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * SLOs API operations (v1)

--- a/src/api/v1/synthetics.ts
+++ b/src/api/v1/synthetics.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Synthetics API operations (v1)

--- a/src/api/v2/cases.ts
+++ b/src/api/v2/cases.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Case Management API operations (v2)

--- a/src/api/v2/fleet-automation.ts
+++ b/src/api/v2/fleet-automation.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Fleet Automation API operations (v2)

--- a/src/api/v2/incidents.ts
+++ b/src/api/v2/incidents.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Incidents API operations (v2)

--- a/src/api/v2/key-management.ts
+++ b/src/api/v2/key-management.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Key Management API operations (v2)

--- a/src/api/v2/logs.ts
+++ b/src/api/v2/logs.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Logs API operations (v2)

--- a/src/api/v2/metrics.ts
+++ b/src/api/v2/metrics.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Metrics API operations (v2)

--- a/src/api/v2/rum.ts
+++ b/src/api/v2/rum.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * RUM API operations (v2)

--- a/src/api/v2/security.ts
+++ b/src/api/v2/security.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Security Monitoring API operations (v2)

--- a/src/api/v2/spans.ts
+++ b/src/api/v2/spans.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Spans/Traces API operations (v2)

--- a/src/api/v2/users.ts
+++ b/src/api/v2/users.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Users API operations (v2)

--- a/src/codegen/go-templates.ts
+++ b/src/codegen/go-templates.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Go code generation templates

--- a/src/codegen/java-templates.ts
+++ b/src/codegen/java-templates.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Java code generation templates

--- a/src/codegen/python-templates.ts
+++ b/src/codegen/python-templates.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Python code generation templates

--- a/src/codegen/rust-templates.ts
+++ b/src/codegen/rust-templates.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Rust code generation templates

--- a/src/codegen/typescript-templates.ts
+++ b/src/codegen/typescript-templates.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * TypeScript code generation templates

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
+
+
 /**
  * CLI entry point for Datadog API Claude Plugin
  * Routes commands to appropriate API handlers

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Datadog API client wrapper with singleton pattern

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Configuration and credential validation for Datadog API

--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Error handling for Datadog API interactions

--- a/src/lib/formatter.ts
+++ b/src/lib/formatter.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Response formatting utilities for Datadog API data

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2024-2026 Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 /**
  * Permission system for Datadog API operations

--- a/tests/__mocks__/inquirer.ts
+++ b/tests/__mocks__/inquirer.ts
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 /**
  * Mock for inquirer module
  */

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 /**
  * Unit tests for config module
  */

--- a/tests/unit/formatter.test.ts
+++ b/tests/unit/formatter.test.ts
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 /**
  * Unit tests for formatter module
  */

--- a/tests/unit/permissions.test.ts
+++ b/tests/unit/permissions.test.ts
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
 /**
  * Unit tests for permissions module with interactive prompts
  */


### PR DESCRIPTION
## Summary

Follow-up to #81 - fixes copyright year format to use "2024-present" instead of "2024-2026" per Datadog OSS standards, and adds missing copyright headers to test files.

## Changes

### Copyright Year Updates
- ✅ **NOTICE** file: `2024-2026` → `2024-present`
- ✅ **LICENSE** file: `2024-2026` → `2024-present`
- ✅ **README.md**: `2024-2026` → `2024-present`
- ✅ All **28 source files**: Updated copyright headers to use `2024-present`

### Added Headers to Test Files
- ✅ `tests/__mocks__/inquirer.ts`
- ✅ `tests/unit/config.test.ts`
- ✅ `tests/unit/formatter.test.ts`
- ✅ `tests/unit/permissions.test.ts`

## Why This Change?

The Datadog OSS policy recommends using "present" instead of a specific end year in copyright notices. This:
- Avoids needing annual updates
- Follows Datadog's standard practice
- Aligns with common open source conventions

Example references:
- https://github.com/DataDog/datadog-api-claude-plugin/blob/93b4a4da2b7f64ead7f850cd5a9cb44fdf2ce54c/NOTICE#L2
- https://github.com/DataDog/datadog-api-claude-plugin/blob/93b4a4da2b7f64ead7f850cd5a9cb44fdf2ce54c/LICENSE#L189

## Testing

- ✅ All tests pass: 95 passed, 95 total
- ✅ Build succeeds
- ✅ No linting errors

## Review Notes

This is a follow-up fix to ensure the repository fully complies with Datadog's OSS policy before the final approval and public release.