### PR TITLE
Release v1.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,9 +6,21 @@
     "email": "support@datadoghq.com"
   },
   "description": "A Claude plugin to use Datadog directly through its APIs with code generation support",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": "https://github.com/DataDog/datadog-api-claude-plugin",
   "homepage": "http://www.datadoghq.com",
+  "keywords": [
+    "datadog",
+    "monitoring",
+    "observability",
+    "metrics",
+    "logs",
+    "traces",
+    "apm",
+    "infrastructure",
+    "security",
+    "devops"
+  ],
   "skills": [
     "./skills/code-generation/SKILL.md",
     "./skills/dd-file-issue/SKILL.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- None
+
+### Changed
+- None
+
+### Fixed
+- None
+
+## [1.15.0] - 2026-02-10
+
+### Added
 - **GitHub Issue Filing Skill**: New `/dd-file-issue` skill to intelligently route issue reports
   - Automatically determines if issue is for pup CLI or plugin repository
   - Searches for existing issues to avoid duplicates
@@ -245,7 +256,11 @@ We follow [Semantic Versioning](https://semver.org/):
 
 ### Linking
 
-- [Unreleased]: https://github.com/DataDog/datadog-api-claude-plugin/compare/v1.0.0...HEAD
+- [Unreleased]: https://github.com/DataDog/datadog-api-claude-plugin/compare/v1.15.0...HEAD
+- [1.15.0]: https://github.com/DataDog/datadog-api-claude-plugin/compare/v1.14.0...v1.15.0
+- [1.14.0]: https://github.com/DataDog/datadog-api-claude-plugin/compare/v1.11.0...v1.14.0
+- [1.11.0]: https://github.com/DataDog/datadog-api-claude-plugin/compare/v1.10.0...v1.11.0
+- [1.10.0]: https://github.com/DataDog/datadog-api-claude-plugin/compare/v1.0.0...v1.10.0
 - [1.0.0]: https://github.com/DataDog/datadog-api-claude-plugin/compare/v0.2.0...v1.0.0
 - [0.2.0]: https://github.com/DataDog/datadog-api-claude-plugin/compare/v0.1.0...v0.2.0
 - [0.1.0]: https://github.com/DataDog/datadog-api-claude-plugin/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datadog API Claude Plugin
 
-[![Version](https://img.shields.io/badge/version-2.0.0-blue.svg)](https://github.com/DataDog/datadog-api-claude-plugin)
+[![Version](https://img.shields.io/badge/version-1.15.0-blue.svg)](https://github.com/DataDog/datadog-api-claude-plugin)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 A comprehensive Claude Code plugin that provides direct integration with Datadog APIs through an agent-based architecture powered by the `pup` CLI tool. Query metrics, manage monitors, create dashboards, search logs, and more—all through natural language interactions with Claude.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-api-claude-plugin",
-  "version": "2.0.0",
+  "version": "1.15.0",
   "description": "A Claude plugin that provides Datadog agents for querying and configuring observability data using the pup CLI tool",
   "keywords": [
     "datadog",
@@ -13,7 +13,8 @@
     "cli"
   ],
   "author": {
-    "name": "DatadogHQ"
+    "name": "Datadog",
+    "email": "support@datadoghq.com"
   },
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Release v1.15.0

This PR prepares the release for version 1.15.0.

### Changes
- Bump version from 2.0.0 to 1.15.0 (correcting version series)
- Fix license field from MIT to Apache-2.0
- Align author metadata across package.json and plugin.json
- Add keywords for marketplace discoverability
- Update CHANGELOG.md with v1.15.0 release notes

### Release Notes

#### Added
- **GitHub Issue Filing Skill**: New `/dd-file-issue` skill to intelligently route issue reports
- **Simplification Documentation**: Added SIMPLIFICATION_PLAN.md and NEXT_STEPS.md
- **Agent Templates**: Created template system to reduce duplication (projected 43.7% reduction)

#### Changed
- **Documentation Modernization**: Updated all docs to reflect pup CLI architecture
- **Simplified .gitignore**: Removed TypeScript-specific build artifacts

#### Removed
- **Obsolete Dependencies**: Removed node_modules/ and package-lock.json
- **TypeScript Examples**: Removed outdated examples/ directory

#### Fixed
- Documentation accuracy: All references now correctly describe pup CLI-based architecture

### Checklist
- [x] Version bumped in plugin.json
- [x] Version aligned in package.json and README.md
- [x] License corrected to Apache-2.0
- [x] Author metadata aligned
- [x] Keywords added for discoverability
- [x] plugin.json validated as valid JSON
- [x] CHANGELOG.md updated
- [ ] PR reviewed and approved
- [ ] Ready to merge

---

### After merge:
1. Tag the release: `git tag -a v1.15.0 -m "Release v1.15.0"`
2. Push tag: `git push origin v1.15.0`
3. Create GitHub release with release notes
4. Submit to Claude marketplace: https://clau.de/plugin-directory-submission