### PR TITLE
fix: remove hardcoded user path

### DIFF
--- a/agents/_templates/README.md
+++ b/agents/_templates/README.md
@@ -74,7 +74,7 @@ Agents reference these templates in their "Important Context" and "Permission Mo
 ```markdown
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/_templates/pup-context.md
+++ b/agents/_templates/pup-context.md
@@ -1,6 +1,6 @@
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/api-management.md
+++ b/agents/api-management.md
@@ -21,7 +21,7 @@ You are a specialized agent for interacting with Datadog's Key Management API. Y
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/apm-configuration.md
+++ b/agents/apm-configuration.md
@@ -28,7 +28,7 @@ You are a specialized agent for managing Datadog APM (Application Performance Mo
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/app-builder.md
+++ b/agents/app-builder.md
@@ -22,7 +22,7 @@ You are a specialized agent for interacting with Datadog's App Builder APIs. You
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/application-security.md
+++ b/agents/application-security.md
@@ -17,7 +17,7 @@ You are a specialized agent for interacting with Datadog's Application Security 
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/audience-management.md
+++ b/agents/audience-management.md
@@ -24,7 +24,7 @@ You are a specialized agent for interacting with Datadog's RUM Audience Manageme
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **API Version**: v2 (Preview/Unstable - subject to changes)
 

--- a/agents/audit-logs.md
+++ b/agents/audit-logs.md
@@ -18,7 +18,7 @@ You are a specialized agent for interacting with Datadog's Audit Trail API. Your
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/aws-integration.md
+++ b/agents/aws-integration.md
@@ -59,7 +59,7 @@ You are a specialized agent for managing Datadog's AWS integration. Your role is
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/azure-integration.md
+++ b/agents/azure-integration.md
@@ -28,7 +28,7 @@ You are a specialized agent for managing Datadog's Microsoft Azure integration. 
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/cicd.md
+++ b/agents/cicd.md
@@ -30,7 +30,7 @@ You are a specialized agent for interacting with Datadog's CI/CD Visibility APIs
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/cloud-cost.md
+++ b/agents/cloud-cost.md
@@ -33,7 +33,7 @@ You are a specialized agent for interacting with Datadog's Cloud Cost Management
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/cloud-workload-security.md
+++ b/agents/cloud-workload-security.md
@@ -17,7 +17,7 @@ You are a specialized agent for interacting with Datadog's Cloud Security Manage
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/container-monitoring.md
+++ b/agents/container-monitoring.md
@@ -29,7 +29,7 @@ Use the Container Monitoring agent when you need to:
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/dashboards.md
+++ b/agents/dashboards.md
@@ -17,7 +17,7 @@ You are a specialized agent for interacting with Datadog's Dashboards API. Your 
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/database-monitoring.md
+++ b/agents/database-monitoring.md
@@ -16,7 +16,7 @@ You are a specialized agent for interacting with Datadog's Database Monitoring (
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/error-tracking.md
+++ b/agents/error-tracking.md
@@ -34,7 +34,7 @@ You are a specialized agent for interacting with Datadog's Error Tracking API. Y
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/events.md
+++ b/agents/events.md
@@ -31,7 +31,7 @@ You are a specialized agent for interacting with Datadog's Events API. Your role
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/fleet-automation.md
+++ b/agents/fleet-automation.md
@@ -30,7 +30,7 @@ You are a specialized agent for interacting with Datadog's Fleet Automation API.
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/gcp-integration.md
+++ b/agents/gcp-integration.md
@@ -39,7 +39,7 @@ You are a specialized agent for managing Datadog's Google Cloud Platform (GCP) i
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/incident-response.md
+++ b/agents/incident-response.md
@@ -97,7 +97,7 @@ This agent supports the complete incident response workflow:
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/infrastructure.md
+++ b/agents/infrastructure.md
@@ -26,7 +26,7 @@ Use the Infrastructure agent when you need to:
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/log-configuration.md
+++ b/agents/log-configuration.md
@@ -42,7 +42,7 @@ You are a specialized agent for managing Datadog log configuration. Your role is
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/logs.md
+++ b/agents/logs.md
@@ -15,7 +15,7 @@ You are a specialized agent for interacting with Datadog's Logs API. Your role i
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/metrics.md
+++ b/agents/metrics.md
@@ -15,7 +15,7 @@ You are a specialized agent for interacting with Datadog's Metrics API. Your rol
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/monitoring-alerting.md
+++ b/agents/monitoring-alerting.md
@@ -57,7 +57,7 @@ This agent covers the entire monitoring and alerting ecosystem in Datadog.
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/network-performance.md
+++ b/agents/network-performance.md
@@ -26,7 +26,7 @@ You are a specialized agent for interacting with Datadog's Network Performance M
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/notebooks.md
+++ b/agents/notebooks.md
@@ -31,7 +31,7 @@ You are a specialized agent for interacting with Datadog's Notebooks API. Your r
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/organization-management.md
+++ b/agents/organization-management.md
@@ -43,7 +43,7 @@ You are a specialized agent for interacting with Datadog's Organization Manageme
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/powerpacks.md
+++ b/agents/powerpacks.md
@@ -24,7 +24,7 @@ You are a specialized agent for interacting with Datadog's Powerpacks API. Your 
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/rum-metrics-retention.md
+++ b/agents/rum-metrics-retention.md
@@ -25,7 +25,7 @@ You are a specialized agent for interacting with Datadog's RUM Metrics and RUM R
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/rum.md
+++ b/agents/rum.md
@@ -15,7 +15,7 @@ You are a specialized agent for interacting with Datadog's Real User Monitoring 
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/saml-configuration.md
+++ b/agents/saml-configuration.md
@@ -16,7 +16,7 @@ You are a specialized agent for configuring SAML Single Sign-On (SSO) in Datadog
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/scorecards.md
+++ b/agents/scorecards.md
@@ -27,7 +27,7 @@ You are a specialized agent for interacting with Datadog's Service Scorecards AP
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/security-posture-management.md
+++ b/agents/security-posture-management.md
@@ -18,7 +18,7 @@ You are a specialized agent for interacting with Datadog's Cloud Security Postur
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/security.md
+++ b/agents/security.md
@@ -15,7 +15,7 @@ You are a specialized agent for interacting with Datadog's Security Monitoring A
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/service-catalog.md
+++ b/agents/service-catalog.md
@@ -38,7 +38,7 @@ You are a specialized agent for interacting with Datadog's Service Catalog and S
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/slos.md
+++ b/agents/slos.md
@@ -15,7 +15,7 @@ You are a specialized agent for interacting with Datadog's Service Level Objecti
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/spark-pod-autosizing.md
+++ b/agents/spark-pod-autosizing.md
@@ -27,7 +27,7 @@ Use the Spark Pod Autosizing agent when you need to:
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/static-analysis.md
+++ b/agents/static-analysis.md
@@ -17,7 +17,7 @@ You are a specialized agent for interacting with Datadog's Code Security feature
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/synthetics.md
+++ b/agents/synthetics.md
@@ -15,7 +15,7 @@ You are a specialized agent for interacting with Datadog's Synthetic Monitoring 
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/third-party-integrations.md
+++ b/agents/third-party-integrations.md
@@ -74,7 +74,7 @@ You are a specialized agent for managing Datadog's third-party integration confi
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/traces.md
+++ b/agents/traces.md
@@ -15,7 +15,7 @@ You are a specialized agent for interacting with Datadog's APM (Application Perf
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/usage-metering.md
+++ b/agents/usage-metering.md
@@ -37,7 +37,7 @@ You are a specialized agent for interacting with Datadog's Usage Metering API. Y
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/user-access-management.md
+++ b/agents/user-access-management.md
@@ -80,7 +80,7 @@ You are a specialized agent for interacting with Datadog's User and Team Managem
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 

--- a/agents/workflows.md
+++ b/agents/workflows.md
@@ -35,7 +35,7 @@ You are a specialized agent for interacting with Datadog's Workflow Automation A
 
 ## Important Context
 
-**Project Location**: `/Users/cody.lee/go/src/github.com/DataDog/datadog-api-claude-plugin`
+**Project Location**: `~/go/src/github.com/DataDog/datadog-api-claude-plugin`
 
 **CLI Tool**: This agent uses the `pup` CLI tool to execute Datadog API commands
 


### PR DESCRIPTION
## What does this PR do?

Removes the hard coded user name with the squiggle thing because Claude kept trying to cd into /Users/cory.lee

## Motivation

<!-- What inspired you to submit this pull request? -->

## Additional Notes

<!-- Anything else we should know when reviewing? -->

## Testing

<!-- How was this change tested? -->

## Checklist

- [ ] The code change is tested and works locally
- [ ] Tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] Lint checks pass (`npm run lint`)
- [ ] Documentation is updated (if applicable)
- [ ] CHANGELOG.md is updated (if user-facing change)
- [ ] Commit messages follow conventional commit format
