### PR TITLE
feat: Support /plugin add from Claude session

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,32 @@
+{
+  "name": "datadog-api-claude-plugin",
+  "owner": {
+    "name": "Datadog",
+    "email": "support@datadoghq.com"
+  },
+  "metadata": {
+    "description": "A Claude Code plugin to interact with Datadog directly through its APIs — query metrics, searchlogs, manage monitors, create dashboards, investigate SLOs, and more using 46 specialized agents.",
+    "version": "1.17.0"
+  },
+  "plugins": [
+    {
+      "name": "datadog-api-claude-plugin",
+      "source": {
+        "source": "github",
+        "repo": "DataDog/datadog-api-claude-plugin",
+        "ref": "main"
+      },
+      "description": "A Claude plugin to use Datadog directly through its APIs with code generation support",
+      "version": "1.17.0",
+      "author": {
+        "name": "Datadog",
+        "email": "support@datadoghq.com"
+      },
+      "homepage": "http://www.datadoghq.com",
+      "repository": "https://github.com/DataDog/datadog-api-claude-plugin",
+      "license": "Apache-2.0",
+      "keywords": ["datadog","monitoring","observability","metrics","logs","traces","apm","infrastructure","security","devops"],
+      "category": "observability"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -122,10 +122,26 @@ See [AGENT_IDENTIFICATION.md](./AGENT_IDENTIFICATION.md) for detailed informatio
 
 ### Prerequisites
 
-- Claude Code CLI
+- [Claude Code CLI](https://docs.anthropic.com/claude/docs/claude-code)
 - [Pup CLI tool](https://github.com/DataDog/pup) installed and available in PATH
 - Datadog account with OAuth2 or API/Application keys
-- Check out this repo `git clone git@github.com:DataDog/datadog-api-claude-plugin.git` and `npx skills add ./datadog-api-claude-plugin`
+
+### Install via Claude Marketplace (Recommended)
+
+```bash
+/plugin add marketplace Datadog/datadog-api-claude-plugin
+```
+
+That's it! The plugin is now available in your Claude Code session.
+
+### Install from Source
+
+Alternatively, clone and install manually:
+
+```bash
+git clone git@github.com:DataDog/datadog-api-claude-plugin.git
+npx skills add ./datadog-api-claude-plugin
+```
 
 ### Setup
 


### PR DESCRIPTION
## What does this PR do?

  Updates README.md with the recommended Claude marketplace installation command and ensures
  `.claude-plugin/marketplace.json` is present for the marketplace listing.

  ## Motivation

  Users can now install the plugin directly from the Claude marketplace with a single command:
```
  /plugin add marketplace Datadog/datadog-api-claude-plugin
```
  This is simpler than manually cloning and installing from source.

  ## Additional Notes

  - README installation section now leads with the marketplace command as the primary/recommended install path
  - Manual source install (`git clone` + `npx skills add`) kept as a fallback option
  - `marketplace.json` defines plugin metadata for the Claude marketplace registry

  ## Testing

  - Verified `marketplace.json` is valid JSON with correct plugin metadata
  - README renders correctly with updated installation instructions

  ## Checklist

  - [x] The code change is tested and works locally
  - [x] Documentation is updated (if applicable)
  - [x] Commit messages follow conventional commit format
  EOF